### PR TITLE
Fixed README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ client = new CartoDB({
 */
 var client = new CartoDB({user: secret.USER,api_key: secret.API_KEY});
 
-client.connect();
-
 client.on('connect', function() {
     console.log("connected");
 
@@ -49,6 +47,8 @@ client.on('connect', function() {
 
 var output = require('fs').createWriteStream(__dirname + '/responses.log');
 client.pipe(output);
+
+client.connect();
 
 ```
 

--- a/examples/pipe.js
+++ b/examples/pipe.js
@@ -8,9 +8,8 @@ var file = require('fs').createWriteStream(__dirname + '/output.json');
 var client = new CartoDB({user:secret.USER, api_key:secret.API_KEY});
 
 client.on('connect', function() {
-  client
-  .query("select * from {table} limit 5", {table: 'tracker'})
-  .query("select * from tracker limit 5 offset 5");
+    client
+        .query("select * from monroecountysnap limit 5");
 });
 
 client.pipe(file);


### PR DESCRIPTION
The current example provided in the README does not actually work. Moving connect to the end of the example mimics the code provided in the examples and will protect new users from undo frustration.
