### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "type": "BSD"
     }
   ],
-  "repositories": [
+  "repository": [
     {
       "type": "git",
       "url": "git://github.com/Vizzuality/cartodb-nodejs.git"


### PR DESCRIPTION
npm WARN package.json cartodb@0.1.1 'repositories' (plural) Not supported. Please pick one as the 'repository' field
