### PR TITLE
Command Line support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,4 +318,28 @@ Options
 $ cartodb -u nerik -f svg 'SELECT * FROM europe' > europe.svg
 $ cartodb -u nerik -f csv 'SELECT cartodb_id, admin, adm_code FROM europe LIMIT 5' -o europe.csv
 $ cartodb -c config.json #hide your api_key there !
+
+```
+
+### Import Module: `cartodb-import`
+
+
+```
+Options
+
+  -f, --file string      Path to a local file to import.
+  -l, --url string       URL to import.
+  -p, --privacy string   Privacy of the generated table (public|private)
+  -u, --user string      Your CartoDB username
+  -a, --api_key string   Your CartoDB API Key (only needed for write operations)
+  -c, --config string    Config file. Use a JSON file as a way to input these arguments.
+  -h, --help
+```
+
+#### Examples
+
+```
+$ cartodb-import -u nerik --api_key XXX test.csv
+$ cartodb-import -c config.json test.csv
+$ cartodb-import -c config.json --url http://sig.pilote41.fr/urbanisme/aleas_inondation/aleas_sauldre_shp.zip
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ sql.pipe(file);
 Import Module
 -------------
 
-(In progress)
 ###Methods
 
 `file` - Import a file from the filesystem - This method is the same as dragging a file (CSV,ZIP,XLS,KML) into the CartoDB GUI. The end result is a table in your account.
@@ -142,7 +141,10 @@ importer
 Named Maps Module
 -----------
 
-###Constructor - Pass in a config object with `user` and `api_key`
+### Constructor
+
+Pass in a config object with `user` and `api_key`
+
 ```
 var namedMaps = new CartoDB.Maps.Named({
     user: 'username',
@@ -150,9 +152,11 @@ var namedMaps = new CartoDB.Maps.Named({
 });
 ```
 
-###Methods - All methods create a promise, and you can listen for `done` and `_error` events.
+### Methods
 
-####`Named.create()` - Create a named map by providing a JSON template
+All methods create a promise, and you can listen for `done` and `_error` events.
+
+#### `Named.create()` - Create a named map by providing a JSON template
 
 Named Map Template:
 ```
@@ -220,7 +224,7 @@ Response:
 ```
 
 
-####`Named.instantiate()` - Instantiate a named map to get a layergroupid, passing an options object with the `template_id`, `auth_token` (if required), and placeholder `params` (if needed by your named map template)
+#### `Named.instantiate()` - Instantiate a named map to get a layergroupid, passing an options object with the `template_id`, `auth_token` (if required), and placeholder `params` (if needed by your named map template)
 ```
 namedMaps.instantiate({
   template_id: 'world_borders',
@@ -244,7 +248,7 @@ Response:
   last_updated: '2016-01-20T20:19:13.152Z' }
 ```
 
-####`Named.update()` - Update a Named Map template
+#### `Named.update()` - Update a Named Map template
 
 ```
 namedMaps.update({
@@ -259,7 +263,7 @@ Response:
 { template_id: 'world_borders' }
 ```
 
-####`Named.delete()` - Delete a named map - pass it an options object with `template_id`
+#### `Named.delete()` - Delete a named map - pass it an options object with `template_id`
 
 ```
 namedMaps.delete({
@@ -273,14 +277,14 @@ Response is the `template_id` that was just deleted:
 ```
 world_borders
 ```
-####`Named.list()` - Get a list of all named maps in your account
+#### `Named.list()` - Get a list of all named maps in your account
 ```
 namedMaps.list()
   .on('done', function(res) {
     console.log(res);
   });
 ```
-####`Named.definition()` - Get the current template for a named map
+#### `Named.definition()` - Get the current template for a named map
 
 ```
 namedMaps.definition({
@@ -289,4 +293,29 @@ namedMaps.definition({
   .on('done', function(res) {
     console.log(res);
   });
+```
+
+Command-line access
+-------------
+
+### SQL Module: `cartodb` / `cartodb-sql`
+
+```
+Options
+
+  -s, --sql string       A SQL query (required).
+  -u, --user string      Your CartoDB username.
+  -a, --api_key string   Your CartoDB API Key (only needed for write operations).
+  -f, --format string    Output format json|csv|geojson|shp|svg|kml|SpatiaLite
+  -o, --output string    Output file. If omitted will use stdout.
+  -c, --config string    Config file. Use a JSON file as a way to input these arguments.
+  -h, --help
+```
+
+#### Examples
+
+```
+$ cartodb -u nerik -f svg 'SELECT * FROM europe' > europe.svg
+$ cartodb -u nerik -f csv 'SELECT cartodb_id, admin, adm_code FROM europe LIMIT 5' -o europe.csv
+$ cartodb -c config.json #hide your api_key there !
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CartoDB client for node.js
 =================================
 
-This library abtsracts calls to CartoDB's SQL and Import APIs.  
+This library abstracts calls to CartoDB's SQL and Import APIs.  
 
 Install
 -------

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here's a simple example to make a SQL API call.
 ```
 var CartoDB = require('cartodb');
 
-var sql = new CartoDB.SQL({user:{USERNAME}, api_key:{APIKEY}})
+var sql = new CartoDB.SQL({user:{USERNAME}})
 
 sql.execute("SELECT * FROM mytable LIMIT 10")
   //you can listen for 'done' and 'error' promise events
@@ -34,26 +34,56 @@ SQL Module
 
 ###Methods
 
-Execute SQL
+#### constructor
+
+```
+var sql = new CartoDB.SQL({
+  user: {USERNAME},
+  api_key: {APIKEY}
+});
+```
+Note: `api_key` is only required for a write query.
+
+#### SQL.execute
+
 `SQL.execute(sql [,vars][, options][, callback])`
 
 `vars` - An object of variables to be rendered with `sql` using Mustache
-`options` - An object for options for the API call.  Only {format: "GeoJSON"} works right now
+
+`options` - An object for options for the API call. Default is `json`.
+```
+{
+  format: 'json'|'csv'|'geojson'|'shp'|'svg'|'kml'|'SpatiaLite'
+}
+```
+More details about formats : [CartoDB SQL API docs](http://docs.cartodb.com/cartodb-platform/sql-api/making-calls/#response-formats)
+
 `callback` - A function that the `data` object will be passed to if the API call is successful.
 
-`.done()` and `.error()` can be chained after `SQL.execute()`.  
+This will return a promise. `.done()` and `.error()` can be chained after `SQL.execute()`.
+
+`.done()` first argument will be either :
+ an object containing  (when using json format) or a raw string (when using all other formats).   
 
 ```
-var sql = new CartoDB.SQL({user:{USERNAME}, api_key:{APIKEY}});
+var sql = new CartoDB.SQL({user:{USERNAME});
 sql.execute("SELECT * from {{table}} LIMIT 5")
   .done(function(data) {
-    //do stuff with the data object
+    console.log(`Executed in ${data.time}, total rows: ${data.total_rows}`);
+    console.log(data.rows[0].cartodb_id)
   })
   .error(function(error) {
     //error contains the error message
-  })
+  });
+```
 
-
+```
+var sql = new CartoDB.SQL({user:{USERNAME}});
+sql.execute("SELECT * from {{table}} LIMIT 5", { format: 'csv' })
+  .done(function(data) {
+    console.log('raw CSV data :');
+    console.log(data);
+  });
 ```
 
 ###Piping

--- a/bin/import.bin.js
+++ b/bin/import.bin.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+var CartoDB = require('../');
+var path = require('path');
+
+var args = [
+  { name: 'file', alias: 'f', type: String, defaultOption: true, description: 'Path to a local file to import.' },
+  { name: 'url', alias: 'l', type: String, description: 'URL to import.' },
+  { name: 'privacy', alias: 'p', type: String, description: 'Privacy of the generated table (public|private)' },
+];
+
+var options = require('../lib/util/cli.js').getCommandLineArgs(args);
+
+if (options.help || (!options.file && !options.url)) {
+  console.log(options.usage);
+  return;
+}
+
+var importer = new CartoDB.Import({
+  user: options.user,
+  api_key: options.api_key
+});
+
+var opts = {
+  privacy: options.privacy || 'public'
+}
+
+var importing;
+if (options.file) {
+  importing = importer.file(options.file, opts);
+} else if (options.url) {
+  importing = importer.url(options.url, opts);
+}
+
+importing.done(function(table_name) {
+  console.log('Table ' + table_name + ' has been created!');
+});

--- a/bin/import.bin.js
+++ b/bin/import.bin.js
@@ -2,11 +2,14 @@
 
 var CartoDB = require('../');
 var path = require('path');
+var Mustache = require('mustache');
+var openurl = require('openurl');
 
 var args = [
   { name: 'file', alias: 'f', type: String, defaultOption: true, description: 'Path to a local file to import.' },
   { name: 'url', alias: 'l', type: String, description: 'URL to import.' },
   { name: 'privacy', alias: 'p', type: String, description: 'Privacy of the generated table (public|private)' },
+  { name: 'opencdb', type: Boolean, description: 'Open result in CartoDB' },
 ];
 
 var options = require('../lib/util/cli.js').getCommandLineArgs(args);
@@ -34,4 +37,10 @@ if (options.file) {
 
 importing.done(function(table_name) {
   console.log('Table ' + table_name + ' has been created!');
+  if (options.opencdb) {
+    openurl.open(Mustache.render('https://{{user}}.cartodb.com/tables/{{table_name}}/map', {
+      user: options.user,
+      table_name: table_name,
+    }));
+  }
 });

--- a/bin/sql.bin.js
+++ b/bin/sql.bin.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+var CartoDB = require('../');
+
+var commandLineArgs = require('command-line-args');
+
+var cli = commandLineArgs([
+  { name: 'sql', alias: 's', type: String, defaultOption: true },
+  { name: 'user', alias: 'u', type: String },
+  { name: 'api_key', alias: 'a', type: String },
+  { name: 'format', alias: 'f', type: String },
+  { name: 'output', alias: 'o', type: String },
+  { name: 'help', alias: 'h' }
+])
+
+var cli_opts = cli.parse();
+
+if (cli_opts.help || !cli_opts.sql) {
+  console.log(cli.getUsage());
+  return;
+}
+
+var sql = new CartoDB.SQL({
+  user: cli_opts.user,
+  api_key: cli_opts.api_key
+});
+
+
+var options = {};
+if (cli_opts.format) options.format = cli_opts.format;
+
+sql.execute(cli_opts.sql, options).done(function (data) {
+  if (cli_opts.output) {
+    var file = require('fs').createWriteStream(cli_opts.output);
+    sql.pipe(file);
+  } else {
+    console.log(data)
+  }
+}).error(function (error) {
+  console.log(error)
+})

--- a/bin/sql.bin.js
+++ b/bin/sql.bin.js
@@ -4,23 +4,24 @@ var CartoDB = require('../');
 
 var commandLineArgs = require('command-line-args');
 
-var cli = commandLineArgs([
-  { name: 'sql', alias: 's', type: String, defaultOption: true },
-  { name: 'user', alias: 'u', type: String },
-  { name: 'api_key', alias: 'a', type: String },
-  { name: 'format', alias: 'f', type: String },
-  { name: 'output', alias: 'o', type: String },
+var args = [
+  { name: 'sql', alias: 's', type: String, defaultOption: true, description: 'A SQL query' },
+  { name: 'user', alias: 'u', type: String, description: 'Your CartoDB username' },
+  { name: 'api_key', alias: 'a', type: String, description: 'Your CartoDB API Key (only needed for write operations)' },
+  { name: 'format', alias: 'f', type: String, description: 'Output format json|csv|geojson|shp|svg|kml|SpatiaLite' },
+  { name: 'output', alias: 'o', type: String, description: 'Output file. If omitted will use stdout' },
+  { name: 'config', alias: 'c', type: String, description: 'Config file.' },
   { name: 'help', alias: 'h' }
-])
+];
+
+var cli = commandLineArgs(args);
 
 var cli_opts = cli.parse();
 
 if (cli_opts.help || !cli_opts.sql) {
-  console.log(cli.getUsage());
+  console.log(cli.getUsage(args));
   return;
 }
-
-console.log(cli_opts.api_key)
 
 var sql = new CartoDB.SQL({
   user: cli_opts.user,
@@ -29,16 +30,16 @@ var sql = new CartoDB.SQL({
 
 
 var options = {};
+
 if (cli_opts.format) options.format = cli_opts.format;
 
+if (cli_opts.output) {
+  var file = require('fs').createWriteStream(cli_opts.output);
+  sql.pipe(file);
+}
+
 sql.execute(cli_opts.sql, options).done(function (data) {
-  if (cli_opts.output) {
-    var file = require('fs').createWriteStream(cli_opts.output);
-    sql.pipe(file);
-  } else {
-    console.log(data)
-  }
+  if (!cli_opts.output) console.log(data)
 }).error(function (error) {
-  console.log('ERROR')
   console.log(error)
 })

--- a/bin/sql.bin.js
+++ b/bin/sql.bin.js
@@ -6,8 +6,6 @@ var args = [
   { name: 'sql', alias: 's', type: String, defaultOption: true, description: 'A SQL query (required).' },
   { name: 'format', alias: 'f', type: String, description: 'Output format json|csv|geojson|shp|svg|kml|SpatiaLite' },
   { name: 'output', alias: 'o', type: String, description: 'Output file. If omitted will use stdout.' },
-  { name: 'config', alias: 'c', type: String, description: 'Config file. Use a JSON file as a way to input these arguments.' },
-  { name: 'help', alias: 'h' }
 ];
 
 var options = require('../lib/util/cli.js').getCommandLineArgs(args);

--- a/bin/sql.bin.js
+++ b/bin/sql.bin.js
@@ -2,44 +2,35 @@
 
 var CartoDB = require('../');
 
-var commandLineArgs = require('command-line-args');
-
 var args = [
-  { name: 'sql', alias: 's', type: String, defaultOption: true, description: 'A SQL query' },
-  { name: 'user', alias: 'u', type: String, description: 'Your CartoDB username' },
-  { name: 'api_key', alias: 'a', type: String, description: 'Your CartoDB API Key (only needed for write operations)' },
+  { name: 'sql', alias: 's', type: String, defaultOption: true, description: 'A SQL query (required)' },
   { name: 'format', alias: 'f', type: String, description: 'Output format json|csv|geojson|shp|svg|kml|SpatiaLite' },
   { name: 'output', alias: 'o', type: String, description: 'Output file. If omitted will use stdout' },
   { name: 'config', alias: 'c', type: String, description: 'Config file.' },
   { name: 'help', alias: 'h' }
 ];
 
-var cli = commandLineArgs(args);
+var options = require('../lib/util/cli.js').getCommandLineArgs(args);
 
-var cli_opts = cli.parse();
-
-if (cli_opts.help || !cli_opts.sql) {
-  console.log(cli.getUsage(args));
+if (options.help || !options.sql) {
+  console.log(options.usage);
   return;
 }
 
 var sql = new CartoDB.SQL({
-  user: cli_opts.user,
-  api_key: cli_opts.api_key
+  user: options.user,
+  api_key: options.api_key
 });
 
-
-var options = {};
-
-if (cli_opts.format) options.format = cli_opts.format;
-
-if (cli_opts.output) {
-  var file = require('fs').createWriteStream(cli_opts.output);
+if (options.output) {
+  var file = require('fs').createWriteStream(options.output);
   sql.pipe(file);
 }
 
-sql.execute(cli_opts.sql, options).done(function (data) {
-  if (!cli_opts.output) console.log(data)
+sql.execute(options.sql, {
+  format: options.format
+}).done(function (data) {
+  if (!options.output) console.log(data)
 }).error(function (error) {
   console.log(error)
-})
+});

--- a/bin/sql.bin.js
+++ b/bin/sql.bin.js
@@ -20,6 +20,8 @@ if (cli_opts.help || !cli_opts.sql) {
   return;
 }
 
+console.log(cli_opts.api_key)
+
 var sql = new CartoDB.SQL({
   user: cli_opts.user,
   api_key: cli_opts.api_key
@@ -37,5 +39,6 @@ sql.execute(cli_opts.sql, options).done(function (data) {
     console.log(data)
   }
 }).error(function (error) {
+  console.log('ERROR')
   console.log(error)
 })

--- a/bin/sql.bin.js
+++ b/bin/sql.bin.js
@@ -3,10 +3,10 @@
 var CartoDB = require('../');
 
 var args = [
-  { name: 'sql', alias: 's', type: String, defaultOption: true, description: 'A SQL query (required)' },
+  { name: 'sql', alias: 's', type: String, defaultOption: true, description: 'A SQL query (required).' },
   { name: 'format', alias: 'f', type: String, description: 'Output format json|csv|geojson|shp|svg|kml|SpatiaLite' },
-  { name: 'output', alias: 'o', type: String, description: 'Output file. If omitted will use stdout' },
-  { name: 'config', alias: 'c', type: String, description: 'Config file.' },
+  { name: 'output', alias: 'o', type: String, description: 'Output file. If omitted will use stdout.' },
+  { name: 'config', alias: 'c', type: String, description: 'Config file. Use a JSON file as a way to input these arguments.' },
   { name: 'help', alias: 'h' }
 ];
 

--- a/lib/import.js
+++ b/lib/import.js
@@ -47,6 +47,7 @@ Import.prototype.file = function(filePath, options) {
     throw new TypeError('filePath should not be null');
   }
 
+  if (!options) options = {};
   options.filePath = filePath;
   options.promise = promise;
   this._post('file',options);
@@ -64,6 +65,7 @@ Import.prototype.url = function(url, options) {
     throw new TypeError('url should not be null');
   }
 
+  if (!options) options = {};
   options.url = url;
   options.promise = promise;
   this._post('url',options);

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -53,7 +53,7 @@ SQL.prototype.execute = function(sql, vars, options, cb) {
   fn = args[args.length -1];
   if(typeof(fn) == 'function') cb = fn;
 
-    //if no brackets in sql, 2nd argument should be options
+  //if no brackets in sql, 2nd argument should be options
   if(sql.match(/({{|}})/) === null) {
     options = vars;
   }
@@ -74,11 +74,15 @@ SQL.prototype.execute = function(sql, vars, options, cb) {
     params = util._extend(params, options);
   }
 
+  if (!params.format) {
+    params.format = 'json';
+  }
+  params.format = params.format.toLowerCase();
+
   //TODO: why use POST if it's a write query?
   if (isGetRequest && !isWriteQuery(query)) {
     request.get({
       url: this.sql_api_url,
-      json: true,
       qs: params
     }, processResponse);
   } else {
@@ -89,12 +93,15 @@ SQL.prototype.execute = function(sql, vars, options, cb) {
   function processResponse(err, res, body) {
     if(!err && res.statusCode === 200) {
       debug('Successful response from the server');
-      self.emit('data', JSON.stringify(body));
-      promise.emit('done', body);
+      self.emit('data', body);
+
+      var promiseWillEmit = (options.format === 'json') ? JSON.parse(body) : body;
+      promise.emit('done', promiseWillEmit);
       if(cb) cb(body);
     } else {
-      debug('There was an error with the request %s', body.error);
-      promise.emit('_error', body.error);
+      var error = JSON.parse(body).error;
+      debug('There was an error with the request %s', error);
+      promise.emit('_error', error);
     }
   }
 

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -86,7 +86,7 @@ SQL.prototype.execute = function(sql, vars, options, cb) {
       qs: params
     }, processResponse);
   } else {
-    request.post({url: this.sql_api_url, json: true, form: params
+    request.post({url: this.sql_api_url, form: params
     }, processResponse);
   }
 
@@ -99,7 +99,7 @@ SQL.prototype.execute = function(sql, vars, options, cb) {
       promise.emit('done', promiseWillEmit);
       if(cb) cb(body);
     } else {
-      var error = JSON.parse(body).error;
+      var error = (body.error) ? body.error : JSON.parse(body).error;
       debug('There was an error with the request %s', error);
       promise.emit('_error', error);
     }

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -1,0 +1,24 @@
+var commonArgs = [
+  { name: 'user', alias: 'u', type: String, description: 'Your CartoDB username' },
+  { name: 'api_key', alias: 'a', type: String, description: 'Your CartoDB API Key (only needed for write operations)' },
+];
+var commandLineArgs = require('command-line-args');
+
+
+module.exports = {
+  getCommandLineArgs: function (customArgs) {
+    var args = customArgs.concat(commonArgs);
+    var cli = commandLineArgs(args);
+    var options = cli.parse();
+
+    if (options.config) {
+      var config = require('fs').readFileSync(options.config, {encoding: 'utf-8'});
+      var configJSON = JSON.parse(config);
+      options = require('util')._extend(options, configJSON);
+    }
+
+    options.usage = cli.getUsage(args);
+
+    return options;
+  }
+}

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -1,6 +1,8 @@
 var commonArgs = [
   { name: 'user', alias: 'u', type: String, description: 'Your CartoDB username' },
   { name: 'api_key', alias: 'a', type: String, description: 'Your CartoDB API Key (only needed for write operations)' },
+  { name: 'config', alias: 'c', type: String, description: 'Config file. Use a JSON file as a way to input these arguments.' },
+  { name: 'help', alias: 'h' }
 ];
 var commandLineArgs = require('command-line-args');
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "command-line-args": "^2.1.6",
     "debug": "~0.7.2",
     "mustache": "^2.2.1",
+    "openurl": "^1.1.1",
     "request": "latest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "bin": {
     "cartodb": "bin/sql.bin.js",
-    "cartodb-sql": "bin/sql.bin.js"
+    "cartodb-sql": "bin/sql.bin.js",
+    "cartodb-import": "bin/import.bin.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "version": "0.3.0",
   "main": "index",
   "url": "https://github.com/CartoDB/cartodb-nodejs",
-  "licenses": [
-    {
-      "type": "BSD"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "repository": [
     {
       "type": "git",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lint": "eslint -c .eslintrc lib"
   },
   "bin": {
-    "cartodb": "bin/sql.bin.js"
+    "cartodb": "bin/sql.bin.js",
+    "cartodb-sql": "bin/sql.bin.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "Erik Escoffier <erik@cartodb.com>"
   ],
   "dependencies": {
+    "command-line-args": "^2.1.6",
     "debug": "~0.7.2",
     "mustache": "^2.2.1",
     "request": "latest"
@@ -42,5 +43,8 @@
     "test:unit": "mocha test/unit",
     "test:functional": "mocha -t 10000 test/functional",
     "lint": "eslint -c .eslintrc lib"
+  },
+  "bin": {
+    "cartodb": "bin/sql.bin.js"
   }
 }


### PR DESCRIPTION
WIP, DO NOT MERGE

Allows you to work with SQL APIs directly in the terminal, without any scripting :
```
$ cartodb -u nerik -f csv 'SELECT cartodb_id, admin, adm_code FROM europe LIMIT 5'
cartodb_id,admin,adm_code
1,Croatia,HRV
2,Ireland,IRL
3,Italy,ITA
4,Moldova,MDA
5,Ukraine,UKR
```

This PR also adds support for file formats other than json in CartoDB.SQL.

Todo before merging :
- [x] CLI support for Import
- [x] documentation on README
- [x] full documentation on CLI
- [ ] provide example with csvkit
- [ ] provide example with [gj2ascii](https://github.com/geowurster/gj2ascii) : MAPS IN YOUR TERMINAL ! HOW AWESUM !
- [ ] `cartodb-geocode` / `whereis`  
- [ ] `cartodb` -> `carto`
- [ ] blog post ?